### PR TITLE
remove file name ref "simple.py" from run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,2 @@
 pip install -r requirements.txt
-python simple.py
 python assert.py


### PR DESCRIPTION
Remove the simple.py file reference, cleaning up an error message 